### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       # - name: Release Files
-        # uses: elgohr/Github-Release-Action@master
+        # uses: elgohr/Github-Release-Action@v4
         # env:
           # GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         # with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore